### PR TITLE
Replace locale_language_list('name') with language_list(FALSE, TRUE)

### DIFF
--- a/path_redirect_import.admin.inc
+++ b/path_redirect_import.admin.inc
@@ -80,7 +80,7 @@ function path_redirect_import_form() {
     '#options' => array(LANGUAGE_NONE => t('All languages')),
   );
   if (module_exists('locale')) {
-    $form['advanced']['langcode']['#options'] = array(LANGUAGE_NONE => t('All languages')) + locale_language_list('name');
+    $form['advanced']['langcode']['#options'] = array(LANGUAGE_NONE => t('All languages')) + language_list(FALSE, TRUE);
   }
 
   $form['actions'] = array(

--- a/path_redirect_import.module
+++ b/path_redirect_import.module
@@ -82,7 +82,7 @@ function path_redirect_import_read_file($file, $options = array()) {
         $line[3] = $options['langcode'];
       }
       else {
-        $language_options = locale_language_list('name');
+        $language_options = language_list(FALSE, TRUE);
         if (!isset($language_options[$line[3]])) {
           $messages[] = t('Line @line_no contains invalid language code', array('@line_no' => $line_no));
           continue;


### PR DESCRIPTION
Replace `locale_language_list('name')` with `language_list(FALSE, TRUE)`.

### Related BackdropCMS change records:

 - One linking to the upstream Drupal API change and containing the fix I propose here in this PR, which fixed a fatal error for my Backdrop 1.31.0 website today and enabled me to successfully import a CSV of redirects:  [language_list() now takes a second parameter to return an array of strings](https://docs.backdropcms.org/change-records/language_list-now-takes-a-second-parameter-to-return-an-array-of-strings)
 - This change record explains a bit more about the Drupal API change:  [language_list() is simplified, locale_language_list() is removed](https://docs.backdropcms.org/change-records/language_list-is-simplified-locale_language_list-is-removed)

### Other links:

BackdropCMS issue: https://github.com/backdrop/backdrop-issues/issues/604
Drupal.org issue: https://www.drupal.org/node/1387608
Drupal.org Changelog: https://www.drupal.org/node/1414264
